### PR TITLE
fixing intl package version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   sembast: ^3.1.1+1
   path_provider: ^2.0.8
-  intl: ^0.17.0
+  intl: ^0.18.0
 
   xxtea: ^2.1.0
   pointycastle: ^3.5.0


### PR DESCRIPTION
after the latest upgrade there is a compatibilty issue due to the intl package should be 0.18.0 and above